### PR TITLE
Fixed typo in jboss-web.xml + added portmapping for run.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
                     <images>
                         <image>
                             <name>${docker.image}</name>
+                            <alias>wildfly</alias>
                             <build>
                                 <from>${docker.from}</from>
                                 <assembly>
@@ -70,6 +71,11 @@
                                     <basedir>/opt/jboss/wildfly/standalone/deployments</basedir>
                                 </assembly>
                             </build>
+                            <run>
+                                <ports>
+                                    <port>8080:8080</port>
+                                </ports>
+                            </run>
                         </image>
                     </images>
                 </configuration>

--- a/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="windows-1252"?>
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
`mvn package docker:build docker:start -Ddocker.follow` will work now and you can then access you application at port 8080 on your docker host.
